### PR TITLE
fix: Remove async from loadMessages on collection

### DIFF
--- a/src/samples/GroupChannelMessageThreading.js
+++ b/src/samples/GroupChannelMessageThreading.js
@@ -737,7 +737,7 @@ const loadChannels = async (channelHandlers) => {
     return [channels, null];
 }
 
-const loadMessages = async (channel, messageHandlers, onCacheResult, onApiResult) => {
+const loadMessages = (channel, messageHandlers, onCacheResult, onApiResult) => {
     const messageFilter = new MessageFilter();
 
     const collection = channel.createMessageCollection({


### PR DESCRIPTION
Removed `async` from `loadMessages` in `GroupChannelMessageThreading` example. It's not needed for collection and not used anywhere else a collection is used. 